### PR TITLE
修复discussions链接无法打开的问题

### DIFF
--- a/profile/CONTRIBUTING.md
+++ b/profile/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Solar 将根据活跃度、贡献质量，授予活跃成员 Solar 积分及核�
 
 ## 📢 开始你的 Solar Builder 之旅
 
-- [进入 Discussions 发起第一条交流](https://github.com/Solana-ZH/discussions)
+- [进入 Discussions 发起第一条交流](https://github.com/orgs/Solana-ZH/discussions)
 - [查看贡献指南](CONTRIBUTING.md)
 - [申请成为 Solar 社区成员](https://docs.google.com/forms/u/1/d/e/1FAIpQLSdwQOjHyctNqpP4FlE6G_tSPUdpWwnIqqGp4SY7CThyfxByIA/viewform?usp=send_form)
 


### PR DESCRIPTION
修复discussions链接无法打开的问题，猜测有可能为权限问题，未登录情况下 url 中没有 /org 无法打开